### PR TITLE
disabled skillTile select issue

### DIFF
--- a/src/components/SkillTile/SkillTile.tsx
+++ b/src/components/SkillTile/SkillTile.tsx
@@ -24,6 +24,11 @@ export default function SkillTile({
         padding: `${0.5 * scale}rem`,
         borderRadius: `${0.8 * scale}rem`,
         gap: `${0.5 * scale}rem`,
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+        MozUserSelect: 'none',
+        msTouchSelect: 'none',
+        msUserSelect: 'none',
         ...containerStyle,
       }}
       className={`${styles.skillTile} ${styles.floatIn} ${visible ? styles.emerge : ''}`}
@@ -56,9 +61,10 @@ export function SkillIcon({
         aspectRatio: 1 / 1,
         boxSizing: "border-box",
         display: "flex",
+
+        // prevent users from selecting text
       }}
     >
-      
       <img
         style={{
           objectFit: "contain",

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,3 +1,5 @@
 export function sleep(ms: number) {
   return new Promise((res) => setTimeout(res, ms));
 }
+
+// skill icon fix comment


### PR DESCRIPTION
Disabled skill tile user select for all browsers using CSS properties.

Fixes annoying text select that happens when they are pressed on mobile.

Fixes #9 